### PR TITLE
Error handling

### DIFF
--- a/app/(tabs)/favorites.tsx
+++ b/app/(tabs)/favorites.tsx
@@ -7,6 +7,7 @@ import EmptyState from '../../src/components/ui/EmptyState';
 import { colors, spacing, typography } from '../../src/theme';
 import { strings } from '../../src/constants/strings';
 import { getFavoriteBags } from '../../src/data';
+import ErrorState from '../../src/components/ui/ErrorState';
 import { useFavorites } from '../../src/context/FavoritesContext';
 import type { BagWithBusiness } from '../../src/types';
 
@@ -16,13 +17,21 @@ export default function FavoritesScreen() {
   const { favoriteBusinessIds, toggleFavorite } = useFavorites();
   const [favoriteBags, setFavoriteBags] = useState<BagWithBusiness[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
     setLoading(true);
-    getFavoriteBags(favoriteBusinessIds).then((bags) => {
-      setFavoriteBags(bags);
-      setLoading(false);
-    });
+    setError(false);
+    getFavoriteBags(favoriteBusinessIds)
+      .then((bags) => {
+        setFavoriteBags(bags);
+      })
+      .catch(() => {
+        setError(true);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
   }, [favoriteBusinessIds]);
 
   const handleBagPress = (bag: BagWithBusiness) => {
@@ -33,6 +42,21 @@ export default function FavoritesScreen() {
     return (
       <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
         <ActivityIndicator size="large" color={colors.primary[500]} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
+        <ErrorState onRetry={() => {
+          setLoading(true);
+          setError(false);
+          getFavoriteBags(favoriteBusinessIds)
+            .then((bags) => setFavoriteBags(bags))
+            .catch(() => setError(true))
+            .finally(() => setLoading(false));
+        }} />
       </View>
     );
   }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -17,6 +17,7 @@ import { colors, spacing } from '../../src/theme';
 import { strings } from '../../src/constants/strings';
 import { CATEGORIES } from '../../src/constants/categories';
 import { getNearbyBags } from '../../src/data';
+import ErrorState from '../../src/components/ui/ErrorState';
 
 import { useFavorites } from '../../src/context/FavoritesContext';
 import type { BagWithBusiness } from '../../src/types';
@@ -29,11 +30,18 @@ export default function DiscoverScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [allBags, setAllBags] = useState<BagWithBusiness[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   const loadBags = useCallback(async () => {
-    const bags: BagWithBusiness[] = await getNearbyBags(strings.discover.latitude, strings.discover.longitude);
-    setAllBags(bags);
-    setLoading(false);
+    try {
+      setError(false);
+      const bags: BagWithBusiness[] = await getNearbyBags(strings.discover.latitude, strings.discover.longitude);
+      setAllBags(bags);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
@@ -73,6 +81,14 @@ export default function DiscoverScreen() {
     return (
       <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
         <ActivityIndicator size="large" color={colors.primary[500]} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
+        <ErrorState onRetry={loadBags} />
       </View>
     );
   }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { colors, spacing, typography, borderRadius } from '../../src/theme';
 import { strings } from '../../src/constants/strings';
 import { getUser, getOrderHistory } from '../../src/data';
+import ErrorState from '../../src/components/ui/ErrorState';
 import Divider from '../../src/components/ui/Divider';
 import type { OrderWithDetails } from '../../src/types';
 
@@ -15,12 +16,19 @@ export default function ProfileScreen() {
   const user = getUser();
   const [orders, setOrders] = useState<OrderWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const loadOrders = () => {
+    setLoading(true);
+    setError(false);
+    getOrderHistory()
+      .then((data) => setOrders(data))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  };
 
   useEffect(() => {
-    getOrderHistory().then((data) => {
-      setOrders(data);
-      setLoading(false);
-    });
+    loadOrders();
   }, []);
 
   const completedOrders = orders.filter((o) => o.status === 'picked_up');
@@ -50,6 +58,14 @@ export default function ProfileScreen() {
     return (
       <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
         <ActivityIndicator size="large" color={colors.primary[500]} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.container, styles.centered, { paddingTop: insets.top }]}>
+        <ErrorState onRetry={loadOrders} />
       </View>
     );
   }

--- a/src/components/ui/ErrorState.tsx
+++ b/src/components/ui/ErrorState.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { colors, typography, spacing } from '../../theme';
+import { strings } from '../../constants/strings';
+import Button from './Button';
+
+interface ErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export default function ErrorState({
+  message = strings.common.error,
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconWrapper}>
+        <Ionicons name="alert-circle-outline" size={56} color={colors.gray[300]} />
+      </View>
+      <Text style={styles.title}>{message}</Text>
+      {onRetry && (
+        <View style={styles.buttonWrapper}>
+          <Button label={strings.common.retry} onPress={onRetry} variant="primary" />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xxxl,
+    paddingVertical: spacing.xxxxl,
+  },
+  iconWrapper: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    backgroundColor: colors.gray[100],
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.xxl,
+  },
+  title: {
+    fontSize: typography.fontSize.lg,
+    fontWeight: typography.fontWeight.bold,
+    color: colors.text.primary,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  buttonWrapper: {
+    marginTop: spacing.xxl,
+  },
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,3 +9,4 @@ export { default as SectionHeader } from './SectionHeader';
 export { default as IconButton } from './IconButton';
 export { default as Divider } from './Divider';
 export { default as EmptyState } from './EmptyState';
+export { default as ErrorState } from './ErrorState';

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -141,6 +141,7 @@ export const strings = {
     loading: 'Cargando...',
     error: 'Algo salio mal',
     retry: 'Reintentar',
+    bagNotFound: 'Bolsa no encontrada',
     cancel: 'Cancelar',
     confirm: 'Confirmar',
     save: 'Guardar',

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -26,7 +26,9 @@
       },
     );
 
-    if (bizError) throw bizError;
+    if (bizError) {
+      throw new Error('Failed to fetch nearby businesses: ' + bizError.message);
+    }
     if (!nearbyBusinesses || nearbyBusinesses.length === 0) return [];
 
     const businessIds = nearbyBusinesses.map((b: { id: string }) => b.id);
@@ -45,7 +47,9 @@
       .in('business_id', businessIds)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) {
+      throw new Error('Failed to fetch nearby bags: ' + error.message);
+    }
     return (data ?? []).map((bag) => {
       const biz = bag.business as Business & { business_categories: { category: Category }[] };
       return {
@@ -109,7 +113,9 @@
       .in('business_id', ids)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) {
+      throw new Error('Failed to fetch bags by category: ' + error.message);
+    }
 
     return (data ?? []).map((bag) => ({
       ...bag,
@@ -137,7 +143,9 @@
       .in('business_id', ids)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) {
+      throw new Error('Failed to fetch favorite bags: ' + error.message);
+    }
 
     return (data ?? []).map((bag) => ({
       ...bag,
@@ -162,7 +170,9 @@
       .or(`title.ilike.%${query}%,description.ilike.%${query}%`)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) {
+      throw new Error('Failed to search bags: ' + error.message);
+    }
 
     return (data ?? []).map((bag) => ({
       ...bag,
@@ -200,7 +210,9 @@
       `)
       .order('created_at', { ascending: false });
 
-    if (error) throw error;
+    if (error) {
+      throw new Error('Failed to fetch order history: ' + error.message);
+    }
 
     return (data ?? []).map((order) => {
       const bag = order.bag as (SurplusBag & { business: Business }) | null;


### PR DESCRIPTION
Errror message, and a Retry button

Wrapped all async data-fetching calls in try/catch/finally blocks across 6 screens: Discover, Browse, Favorites, Profile, Bag Detail, and Checkout Each screen now tracks an error state and renders the ErrorState component with a retry callback that re-triggers the original data fetch Improved error messages in the data layer .

Supabase errors now re-throw with descriptive messages 
Extracted the hardcoded Bolsa no encontrada string into strings.common.bagNotFound for consistency Exported ErrorState from the UI component barrel file Resolved all 9 lint warnings:

Fixed react-hooks/exhaustive-deps in bag/[id].tsx and checkout/[bagId].tsx by wrapping loadBag in useCallback
 Removed unused ErrorState import in order-history.tsx 
Removed 6 console.error calls in src/data/index.ts (errors are already thrown with descriptive messages)